### PR TITLE
Fix byte-compiler/package-lint/check-doc warnings

### DIFF
--- a/outline-toc.el
+++ b/outline-toc.el
@@ -34,17 +34,18 @@
 
 ;;; Commentary:
 
-;; This provides a sidebar buffer which shows a "table of contents" for an
-;; associated outline-mode buffer. Basically, this shows you the sections of the
-;; outline-mode buffer, but not the bodies. This is to help you remember where
-;; you are in a large document.
+;; This provides a sidebar buffer which shows a "table of
+;; contents" for an associated outline-mode buffer.  Basically,
+;; this shows you the sections of the outline-mode buffer, but
+;; not the bodies.  This is to help you remember where you are in
+;; a large document.
 
-;; Simply use M-x outline-toc-mode to toggle activation of the outline-toc.
-;; Use 'M-x customize-group RET outline-toc RET' to adapt outline-toc to your
-;; needs.
+;; Simply use M-x outline-toc-mode to toggle activation of the
+;; outline-toc.  Use 'M-x customize-group RET outline-toc RET' to
+;; adapt outline-toc to your needs.
 
-;; Much of this was originally adapated from David Engster's excellent
-;; minimap.el (https://github.com/dengste/minimap).
+;; Much of this was originally adapated from David Engster's
+;; excellent minimap.el (https://github.com/dengste/minimap).
 
 ;;; Code:
 

--- a/outline-toc.el
+++ b/outline-toc.el
@@ -49,6 +49,8 @@
 
 ;;; Code:
 
+(require 'outline)
+
 (defgroup outline-toc nil
   "A outline-toc sidebar."
   :group 'convenience)


### PR DESCRIPTION
Hi!
I found this package, and I want to contribute to fix some of
byte-compiler/package-lint/check-doc warnings as my first
contribution step!

Please review this!

### after
```elisp
 outline-…    38     warning         There should be two spaces after a period (emacs-lisp-checkdoc)
 outline…    39     warning         There should be two spaces after a period (emacs-lisp-checkdoc)
 outline…   359   1 warning         the following functions are not known to be defined:
                                  outline-toc-setup-hooks, outline-hide-body,
                                  outline-show-all, outline-previous-heading (emacs-lisp) 
```

### before
 outline…   362   1 warning         the function ‘outline-toc-setup-hooks’ is not known to be defined. (emacs-lisp)